### PR TITLE
Add libcublas-dev, libcusolver-dev, libcusparse-dev to build/host deps

### DIFF
--- a/recipe/build-torch.sh
+++ b/recipe/build-torch.sh
@@ -3,19 +3,8 @@ set -ex
 if [[ "$cuda_compiler_version" == "None" ]]; then
   export FORCE_CUDA=0
 else
-  export TORCH_CUDA_ARCH_LIST="3.5;5.0"
-  if [[ ${cuda_compiler_version} == 9.0* ]]; then
-      export TORCH_CUDA_ARCH_LIST="$TORCH_CUDA_ARCH_LIST;6.0;7.0"
-  elif [[ ${cuda_compiler_version} == 9.2* ]]; then
-      export TORCH_CUDA_ARCH_LIST="$TORCH_CUDA_ARCH_LIST;6.0;6.1;7.0"
-  elif [[ ${cuda_compiler_version} == 10.* ]]; then
-      export TORCH_CUDA_ARCH_LIST="$TORCH_CUDA_ARCH_LIST;6.0;6.1;7.0;7.5"
-  elif [[ ${cuda_compiler_version} == 11.0* ]]; then
-      export TORCH_CUDA_ARCH_LIST="$TORCH_CUDA_ARCH_LIST;6.0;6.1;7.0;7.5;8.0"
-  elif [[ ${cuda_compiler_version} == 11.1* ]]; then
-      export TORCH_CUDA_ARCH_LIST="$TORCH_CUDA_ARCH_LIST;6.0;6.1;7.0;7.5;8.0;8.6"
-  elif [[ ${cuda_compiler_version} == 11.2* ]]; then
-      export TORCH_CUDA_ARCH_LIST="$TORCH_CUDA_ARCH_LIST;6.0;6.1;7.0;7.5;8.0;8.6"
+  if [[ ${cuda_compiler_version} == 11.2* ]]; then
+      export TORCH_CUDA_ARCH_LIST="3.5;5.0;6.0;6.1;7.0;7.5;8.0;8.6"
   elif [[ ${cuda_compiler_version} == 11.8 ]]; then
       export TORCH_CUDA_ARCH_LIST="3.5;5.0;6.0;6.1;7.0;7.5;8.0;8.6;8.9"
       export CUDA_TOOLKIT_ROOT_DIR=$CUDA_HOME

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,6 +7,12 @@
 # updated every 0.x release. https://github.com/pytorch/vision#installation
 {% set compatible_pytorch = "2.1" %}
 
+{% if cuda_compiler_version in (None, "None", True, False) %}
+{% set cuda_major = 0 %}
+{% else %}
+{% set cuda_major = environ.get("cuda_compiler_version", "11.8").split(".")[0] | int %}
+{% endif %}
+
 package:
   name: torchvision-split
   version: {{ version }}
@@ -47,6 +53,11 @@ outputs:
         - {{ compiler('c') }}
         - {{ compiler('cxx') }}
         - {{ compiler('cuda') }}                 # [cuda_compiler_version != "None"]
+        {% if cuda_major >= 12 %}
+        - libcublas-dev                          # [build_platform != target_platform]
+        - libcusolver-dev                        # [build_platform != target_platform]
+        - libcusparse-dev                        # [build_platform != target_platform]
+        {% endif %}
         - sysroot_linux-64 ==2.17                # [linux64]
         - python                                 # [build_platform != target_platform]
         - cross-python_{{ target_platform }}     # [build_platform != target_platform]
@@ -57,6 +68,11 @@ outputs:
         - pip
         - setuptools
         - cudnn                                  # [cuda_compiler_version != "None"]
+        {% if cuda_major >= 12 %}
+        - libcublas-dev
+        - libcusolver-dev
+        - libcusparse-dev
+        {% endif %}
         # split off image/video into separate outputs?
         - libjpeg-turbo
         - libpng


### PR DESCRIPTION
Patch for https://github.com/conda-forge/torchvision-feedstock/pull/85 to add missing build and host dependencies.